### PR TITLE
Removed templates/assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 vendor/node_modules
 vendor/.grunt
 vendor/bower_components
-templates/assets/
 .npm-debug.log


### PR DESCRIPTION
When grunt watch runs it compiles into templates/assets so when pushing
to stage or prod no styles, scripts or images got pushed. 
