### PR TITLE
Added grunt-svgmin task to optimise SVGs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,6 +10,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-exorcise')
   grunt.loadNpmTasks('grunt-contrib-copy')
   grunt.loadNpmTasks('grunt-contrib-clean')
+  grunt.loadNpmTasks('grunt-svgmin')
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
@@ -88,6 +89,20 @@ module.exports = function (grunt) {
       }
     },
 
+    svgmin: {
+      options: {},
+      dist: {
+        files: [
+          {
+            expand: true,
+            cwd: 'assets/img/',
+            src: ['*.svg'],
+            dest: 'static/img/'
+          }
+        ]
+      }
+    },
+
     _watch: {
       less: {
         files: ['assets/scss/*.scss', 'assets/scss/*/*.scss'],
@@ -138,6 +153,7 @@ module.exports = function (grunt) {
     'bower-install',
     'img-mkdir',
     'img',
+    'svgmin',
     'sass',
     'standard',
     'copy',

--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "grunt-sass": "^1.2.0",
     "grunt-contrib-watch": "~0.6.0",
     "grunt-exorcise": "^2.1.1",
-    "grunt-img": "~0.1.0",
+    "grunt-img": "~0.1.8",
     "grunt-modernizr": "^1.0.2",
-    "grunt-standard": "^2.0.0"
+    "grunt-standard": "^2.0.0",
+    "grunt-svgmin": "^4.0.0"
   }
 }


### PR DESCRIPTION
Added new grunt task for SVGs.

Previously SVGs weren't optimised and moved to the `static/img` directory so we had to do this manually every time after running `grunt` (this command is creating the whole directory from scratch).

`grunt-svgmin` task adds SVGs to that folder.