### PR TITLE
Fix/Do not prefetch without specific asset

### DIFF
--- a/app/Theme/Scripts.php
+++ b/app/Theme/Scripts.php
@@ -56,12 +56,6 @@ class Scripts implements \Dxw\Iguana\Registerable
         ?>
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-        <!-- Prefetch external asset dns -->
-        <link rel="dns-prefetch" href="#">
-
-        <!-- Prefetch internal image assets -->
-        <link rel="prefetch" href="#">
-
         <link rel="apple-touch-icon-precomposed" href="<?php $this->assetPath('img/apple-touch-icon-precomposed.png') ?>">
 
         <link rel="icon" type="image/png" href="<?php $this->assetPath('img/shortcut-icon.png') ?>">

--- a/tests/theme/scripts_test.php
+++ b/tests/theme/scripts_test.php
@@ -116,12 +116,6 @@ class Theme_Scripts_Test extends PHPUnit_Framework_TestCase
         $this->expectOutputString(implode("\n", [
             '        <meta name="viewport" content="width=device-width, initial-scale=1.0">',
             '',
-            '        <!-- Prefetch external asset dns -->',
-            '        <link rel="dns-prefetch" href="#">',
-            '',
-            '        <!-- Prefetch internal image assets -->',
-            '        <link rel="prefetch" href="#">',
-            '',
             '        <link rel="apple-touch-icon-precomposed" href="_http://a.invalid/static/img/apple-touch-icon-precomposed.png_">',
             '',
             '        <link rel="icon" type="image/png" href="_http://a.invalid/static/img/shortcut-icon.png_">',


### PR DESCRIPTION
`<link rel="prefetch">` should only be used with an href of a specific
asset. Using an href of # causes caching errors in the WordPress backend
which makes it appear that edits are not being saved.

Resolves: https://trello.com/c/FXdbbKm7/58-bug-wp-doesn-t-save-content