### PR TITLE
Optional plugin dependency check

### DIFF
--- a/app/Theme/Plugins.php
+++ b/app/Theme/Plugins.php
@@ -23,7 +23,10 @@ class Plugins implements Registerable
     public function checkDependencies()
     {
         $pluginsToActivate = $this->findPluginsToActivate();
-        if (!empty($pluginsToActivate) && !function_exists('get_plugins')) {
+        if (empty($pluginsToActivate)) {
+            return;
+        }
+        if (!function_exists('get_plugin_data')) {
             require_once($this->path_to_wordpress . 'wp-admin/includes/plugin.php');
         }
         array_map([$this, 'addNotice'], $pluginsToActivate);
@@ -41,7 +44,6 @@ class Plugins implements Registerable
             </p>
         </div>
         <?php
-
     }
 
     /**

--- a/app/Theme/Plugins.php
+++ b/app/Theme/Plugins.php
@@ -9,10 +9,10 @@ class Plugins implements Registerable
     protected $required;
     protected $path_to_wordpress;
 
-    public function __construct(array $required = [], $path_to_wordpress = ABSPATH)
+    public function __construct(array $required = [])
     {
         $this->required = $required;
-        $this->path_to_wordpress = $path_to_wordpress;
+        $this->path_to_wordpress = ABSPATH;
     }
 
     public function register()
@@ -44,6 +44,7 @@ class Plugins implements Registerable
             </p>
         </div>
         <?php
+
     }
 
     /**

--- a/app/Theme/Plugins.php
+++ b/app/Theme/Plugins.php
@@ -7,12 +7,12 @@ use Dxw\Iguana\Registerable;
 class Plugins implements Registerable
 {
     protected $required;
-    protected $abspath;
+    protected $path_to_wordpress;
 
-    public function __construct(array $required = [], $abspath = null)
+    public function __construct(array $required = [], $path_to_wordpress = ABSPATH)
     {
         $this->required = $required;
-        $this->abspath = $abspath ?? ABSPATH;
+        $this->path_to_wordpress = $path_to_wordpress;
     }
 
     public function register()
@@ -24,7 +24,7 @@ class Plugins implements Registerable
     {
         $pluginsToActivate = $this->findPluginsToActivate();
         if (!empty($pluginsToActivate) && !function_exists('get_plugins')) {
-            require_once($this->abspath . 'wp-admin/includes/plugin.php');
+            require_once($this->path_to_wordpress . 'wp-admin/includes/plugin.php');
         }
         array_map([$this, 'addNotice'], $pluginsToActivate);
     }

--- a/app/di.php
+++ b/app/di.php
@@ -27,3 +27,8 @@ $registrar->addInstance(\Dxw\MyTheme\Theme\Pagination::class, new \Dxw\MyTheme\T
 // Post types and additional fields
 $registrar->addInstance(\Dxw\MyTheme\Posts\PostTypes::class, new \Dxw\MyTheme\Posts\PostTypes());
 $registrar->addInstance(\Dxw\MyTheme\Posts\CustomFields::class, new \Dxw\MyTheme\Posts\CustomFields());
+
+// Plugin dependency check - pass in any required plugins
+$registrar->addInstance(\Dxw\MyTheme\Theme\Plugins::class, new \Dxw\MyTheme\Theme\Plugins([
+//    'advanced-custom-fields/acf.php', // Path to main plugin file
+]));

--- a/spec/theme/plugins.spec.php
+++ b/spec/theme/plugins.spec.php
@@ -8,9 +8,9 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                 return '_'.$a.'_';
             },
         ]);
-        $this->abspath = \org\bovigo\vfs\vfsStream::setup()->url() . '/';
-        mkdir($this->abspath.'wp-admin/includes', 0755, true);
-        file_put_contents($this->abspath.'/wp-admin/includes/plugin.php', '');
+        $this->fake_path_to_wp = \org\bovigo\vfs\vfsStream::setup()->url() . '/';
+        mkdir($this->fake_path_to_wp.'wp-admin/includes', 0755, true);
+        file_put_contents($this->fake_path_to_wp.'/wp-admin/includes/plugin.php', '');
         if (!defined('WP_PLUGIN_DIR')) {
             define('WP_PLUGIN_DIR', '/path/to/plugins');
         }
@@ -23,7 +23,7 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
     it('is registrable', function () {
         $plugins = new \Dxw\MyTheme\Theme\Plugins(
             [],
-            $this->abspath
+            $this->fake_path_to_wp
         );
         expect($plugins)->to->be->an->instanceof(\Dxw\Iguana\Registerable::class);
     });
@@ -32,7 +32,7 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
         it('registers theme activation hook', function () {
             $plugins = new \Dxw\MyTheme\Theme\Plugins(
                 [],
-                $this->abspath
+                $this->fake_path_to_wp
             );
             \WP_Mock::expectActionAdded('after_switch_theme', [$plugins, 'checkDependencies']);
             $plugins->register();
@@ -72,7 +72,7 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                     'path-to/a-required-plugin.php',
                     'advanced-custom-fields-pro/acf.php'
                 ],
-                $this->abspath
+                $this->fake_path_to_wp
             );
             ob_start();
             $plugins->checkDependencies();
@@ -102,7 +102,7 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                         'path-to/a-required-plugin.php',
                         'advanced-custom-fields-pro/acf.php'
                     ],
-                    $this->abspath
+                    $this->fake_path_to_wp
                 );
                 ob_start();
                 $plugins->checkDependencies();
@@ -139,7 +139,7 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                         'path-to/a-required-plugin.php',
                         'advanced-custom-fields-pro/acf.php'
                     ],
-                    $this->abspath
+                    $this->fake_path_to_wp
                 );
                 ob_start();
                 $plugins->checkDependencies();

--- a/spec/theme/plugins.spec.php
+++ b/spec/theme/plugins.spec.php
@@ -8,9 +8,6 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                 return '_'.$a.'_';
             },
         ]);
-        $this->fake_path_to_wp = \org\bovigo\vfs\vfsStream::setup()->url() . '/';
-        mkdir($this->fake_path_to_wp.'wp-admin/includes', 0755, true);
-        file_put_contents($this->fake_path_to_wp.'/wp-admin/includes/plugin.php', '');
         if (!defined('WP_PLUGIN_DIR')) {
             define('WP_PLUGIN_DIR', '/path/to/plugins');
         }
@@ -21,19 +18,13 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
     });
 
     it('is registrable', function () {
-        $plugins = new \Dxw\MyTheme\Theme\Plugins(
-            [],
-            $this->fake_path_to_wp
-        );
+        $plugins = new \Dxw\MyTheme\Theme\Plugins([]);
         expect($plugins)->to->be->an->instanceof(\Dxw\Iguana\Registerable::class);
     });
 
     describe('->register()', function () {
         it('registers theme activation hook', function () {
-            $plugins = new \Dxw\MyTheme\Theme\Plugins(
-                [],
-                $this->fake_path_to_wp
-            );
+            $plugins = new \Dxw\MyTheme\Theme\Plugins([]);
             \WP_Mock::expectActionAdded('after_switch_theme', [$plugins, 'checkDependencies']);
             $plugins->register();
         });
@@ -65,21 +56,18 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
             WP_Mock::wpFunction('admin_url', [
                 'args' => ['plugins.php'],
                 'times' => 2,
-                'return' => '__http://localhost/wp-admin/plugins.php__'
+                'return' => 'http://localhost/wp-admin/plugins.php'
             ]);
-            $plugins = new \Dxw\MyTheme\Theme\Plugins(
-                [
-                    'path-to/a-required-plugin.php',
-                    'advanced-custom-fields-pro/acf.php'
-                ],
-                $this->fake_path_to_wp
-            );
+            $plugins = new \Dxw\MyTheme\Theme\Plugins([
+                'path-to/a-required-plugin.php',
+                'advanced-custom-fields-pro/acf.php'
+            ]);
             ob_start();
             $plugins->checkDependencies();
             $result = ob_get_contents();
             ob_end_clean();
             expect($result)->to->contain('<div class="notice notice-warning">');
-            expect($result)->to->contain('<a href="__http://localhost/wp-admin/plugins.php__">Visit plugins page</a>');
+            expect($result)->to->contain('<a href="http://localhost/wp-admin/plugins.php">Visit plugins page</a>');
             expect($result)->to->contain('</div>');
 
             expect($result)->to->contain('<strong>_A plugin_</strong>');
@@ -97,13 +85,10 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                         'advanced-custom-fields-pro/acf.php'
                     ]
                 ]);
-                $plugins = new \Dxw\MyTheme\Theme\Plugins(
-                    [
-                        'path-to/a-required-plugin.php',
-                        'advanced-custom-fields-pro/acf.php'
-                    ],
-                    $this->fake_path_to_wp
-                );
+                $plugins = new \Dxw\MyTheme\Theme\Plugins([
+                    'path-to/a-required-plugin.php',
+                    'advanced-custom-fields-pro/acf.php'
+                ]);
                 ob_start();
                 $plugins->checkDependencies();
                 $result = ob_get_contents();
@@ -132,15 +117,12 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                 WP_Mock::wpFunction('admin_url', [
                     'args' => ['plugins.php'],
                     'times' => 1,
-                    'return' => '__http://localhost/wp-admin/plugins.php__'
+                    'return' => 'http://localhost/wp-admin/plugins.php'
                 ]);
-                $plugins = new \Dxw\MyTheme\Theme\Plugins(
-                    [
-                        'path-to/a-required-plugin.php',
-                        'advanced-custom-fields-pro/acf.php'
-                    ],
-                    $this->fake_path_to_wp
-                );
+                $plugins = new \Dxw\MyTheme\Theme\Plugins([
+                    'path-to/a-required-plugin.php',
+                    'advanced-custom-fields-pro/acf.php'
+                ]);
                 ob_start();
                 $plugins->checkDependencies();
                 $result = ob_get_contents();

--- a/spec/theme/plugins.spec.php
+++ b/spec/theme/plugins.spec.php
@@ -9,13 +9,6 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
             },
         ]);
         $this->abspath = \org\bovigo\vfs\vfsStream::setup()->url() . '/';
-        $this->plugins = new \Dxw\MyTheme\Theme\Plugins(
-            [
-                'path-to/a-required-plugin.php',
-                'advanced-custom-fields-pro/acf.php'
-            ],
-            $this->abspath
-        );
         mkdir($this->abspath.'wp-admin/includes', 0755, true);
         file_put_contents($this->abspath.'/wp-admin/includes/plugin.php', '');
         if (!defined('WP_PLUGIN_DIR')) {
@@ -28,13 +21,21 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
     });
 
     it('is registrable', function () {
-        expect($this->plugins)->to->be->an->instanceof(\Dxw\Iguana\Registerable::class);
+        $plugins = new \Dxw\MyTheme\Theme\Plugins(
+            [],
+            $this->abspath
+        );
+        expect($plugins)->to->be->an->instanceof(\Dxw\Iguana\Registerable::class);
     });
 
     describe('->register()', function () {
         it('registers theme activation hook', function () {
-            \WP_Mock::expectActionAdded('after_switch_theme', [$this->plugins, 'checkDependencies']);
-            $this->plugins->register();
+            $plugins = new \Dxw\MyTheme\Theme\Plugins(
+                [],
+                $this->abspath
+            );
+            \WP_Mock::expectActionAdded('after_switch_theme', [$plugins, 'checkDependencies']);
+            $plugins->register();
         });
     });
 
@@ -66,8 +67,15 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                 'times' => 2,
                 'return' => '__http://localhost/wp-admin/plugins.php__'
             ]);
+            $plugins = new \Dxw\MyTheme\Theme\Plugins(
+                [
+                    'path-to/a-required-plugin.php',
+                    'advanced-custom-fields-pro/acf.php'
+                ],
+                $this->abspath
+            );
             ob_start();
-            $this->plugins->checkDependencies();
+            $plugins->checkDependencies();
             $result = ob_get_contents();
             ob_end_clean();
             expect($result)->to->contain('<div class="notice notice-warning">');
@@ -89,9 +97,15 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                         'advanced-custom-fields-pro/acf.php'
                     ]
                 ]);
-
+                $plugins = new \Dxw\MyTheme\Theme\Plugins(
+                    [
+                        'path-to/a-required-plugin.php',
+                        'advanced-custom-fields-pro/acf.php'
+                    ],
+                    $this->abspath
+                );
                 ob_start();
-                $this->plugins->checkDependencies();
+                $plugins->checkDependencies();
                 $result = ob_get_contents();
                 ob_end_clean();
                 expect($result)->to->be->empty;
@@ -120,8 +134,15 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
                     'times' => 1,
                     'return' => '__http://localhost/wp-admin/plugins.php__'
                 ]);
+                $plugins = new \Dxw\MyTheme\Theme\Plugins(
+                    [
+                        'path-to/a-required-plugin.php',
+                        'advanced-custom-fields-pro/acf.php'
+                    ],
+                    $this->abspath
+                );
                 ob_start();
-                $this->plugins->checkDependencies();
+                $plugins->checkDependencies();
                 $result = ob_get_contents();
                 ob_end_clean();
 
@@ -129,6 +150,4 @@ describe(\Dxw\MyTheme\Theme\Plugins::class, function () {
             });
         });
     });
-
-
 });


### PR DESCRIPTION
Some of our themes have a dependency on one or more plugins. Most of the time it isn't documented anywhere and can cause confusion when new developers pick up the project.

This commit adds a plugin dependency check where developers can define the plugins required to run the theme in `di.php`

The checks will be ran when the theme is activated and any plugins that are required and not active will have a 'warning' message displayed.